### PR TITLE
arsig: fix macOS (Apple clang) build of xgb_model.c

### DIFF
--- a/src/arsig/Makefile
+++ b/src/arsig/Makefile
@@ -11,6 +11,11 @@ OBJ_PATH = .obj/
 FTN = gfortran
 FFLAGS = -g -O0
 CFLAGS = -std=c99
+# Apple clang caps C bracket nesting at 256; the generated xgb_model.c exceeds it.
+# GNU gcc has no such limit and rejects -fbracket-depth, so add it for clang only.
+ifneq (,$(findstring clang,$(shell gcc --version 2>/dev/null)))
+  CFLAGS += -fbracket-depth=1024
+endif
 
 LIBCOM = ../lib/libcom.a
 
@@ -33,7 +38,7 @@ $(OBJ_PATH)%.o : %.f90
 	
 $(OBJ_PATH)%.o : %.c
 	$(DIR_GUARD)
-	gcc $(CFLAGS) -c $< -o $@
+	ulimit -s $$(ulimit -Hs) 2>/dev/null || true; gcc $(CFLAGS) -c $< -o $@
 
 
  


### PR DESCRIPTION
## Problem

On macOS, the C compiler invoked as `gcc` is **Apple clang**. Building from a
clean tree fails in `arsig` while compiling the generated `src/arsig/xgb_model.c`
(the SVM/XGBoost integer-ambiguity-validation model):

```
xgb_model.c:102084:298: fatal error: bracket nesting level exceeded maximum of 256
xgb_model.c:102084:298: note: use -fbracket-depth=N to increase maximum nesting level
1 error generated.
```

Apple clang caps C bracket nesting at 256; that generated file exceeds it.
GNU gcc (Linux) has no such default limit, which is why CI/Linux builds are
unaffected.

## Why the obvious one-liner is not enough

Adding `-fbracket-depth=1024` lifts the 256 limit, but clang parses via
recursive descent, and on the **default macOS stack of 8 MB** (`ulimit -s`
= 8192) the parser then **overflows the stack and segfaults** on this very
deeply nested file:

```
clang: error: unable to execute command: Segmentation fault: 11
clang: error: clang frontend command failed due to signal
```

So a robust fix must (a) raise the bracket-depth limit **and** (b) give the
compiler enough stack.

## Fix (`src/arsig/Makefile`, no effect on GNU/Linux)

- add `-fbracket-depth=1024` **only when the C compiler is clang** (GNU gcc has
  no such limit and *rejects* the flag with `unrecognized command-line option`);
- raise the stack soft limit to the hard limit for the C compile step so
  clang's recursive parser does not overflow.

```make
CFLAGS = -std=c99
ifneq (,$(findstring clang,$(shell gcc --version 2>/dev/null)))
  CFLAGS += -fbracket-depth=1024
endif
...
$(OBJ_PATH)%.o : %.c
	$(DIR_GUARD)
	ulimit -s $$(ulimit -Hs) 2>/dev/null || true; gcc $(CFLAGS) -c $< -o $@
```

## Testing (macOS arm64, Apple clang 17; Homebrew GNU gcc-16)

| compiler | flag | stack | result |
|---|---|---|---|
| Apple clang | none (current) | 8 MB | fail: bracket nesting > 256 |
| GNU gcc-16 | none | 8 MB | OK (no limit; flag not needed) |
| GNU gcc-16 | `-fbracket-depth` | 8 MB | fail: unrecognized option (flag must be clang-only) |
| Apple clang | `-fbracket-depth` | 8 MB | segfault (parser stack overflow) |
| Apple clang | `-fbracket-depth` | hard (64 MB) | OK |

With this patch, a full `install.sh` build completes on macOS under the default
8 MB stack, and GNU gcc builds the file unchanged (flag not added).

## Alternative

The stack bump could instead live once in `install.sh` (global `ulimit -s`
before the build) rather than in the `arsig` recipe; happy to move it there if
preferred. Opened as a draft for maintainer feedback on the approach.